### PR TITLE
ci: harden dependency and installer workflows

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -13,23 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'ohmyzsh/ohmyzsh'
     permissions:
-      contents: write # this is needed to push commits and branches
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - name: Authenticate as @ohmyzsh
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ secrets.OHMYZSH_CLIENT_ID }}
           private-key: ${{ secrets.OHMYZSH_APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -42,5 +43,5 @@ jobs:
           GIT_APP_EMAIL: 54982679+ohmyzsh[bot]@users.noreply.github.com
           TMP_DIR: ${{ runner.temp }}
         run: |
-          pip install -r .github/workflows/dependencies/requirements.txt
+          python3 -m pip install --require-hashes -r .github/workflows/dependencies/requirements.txt
           python3 .github/workflows/dependencies/updater.py

--- a/.github/workflows/dependencies/requirements.txt
+++ b/.github/workflows/dependencies/requirements.txt
@@ -1,7 +1,7 @@
-certifi==2026.2.25
-charset-normalizer==3.4.7
-idna==3.11
-PyYAML==6.0.3
-requests==2.33.1
-semver==3.0.4
-urllib3==2.6.3
+certifi==2026.2.25 --hash=sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
+charset-normalizer==3.4.7 --hash=sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116
+idna==3.11 --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+requests==2.33.1 --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+semver==3.0.4 --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746
+urllib3==2.6.3 --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -53,14 +53,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Vercel CLI
-        run: npm install -g vercel
       - name: Setup project and deploy
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_CLI_VERSION: 41.7.3
         run: |
           cp tools/install.sh .github/workflows/installer/install.sh
           cd .github/workflows/installer
-          vc deploy --prod -t "$VERCEL_TOKEN"
+          npx --yes vercel@${VERCEL_CLI_VERSION} deploy --prod -t "$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary
- reduce `dependencies.yml` job token scope to read-only and use the GitHub App token for checkout/push operations
- enforce hash-verified Python installs for dependency updater requirements (`--require-hashes`)
- replace global unpinned Vercel CLI install with version-pinned `npx vercel@41.7.3` in installer deployment

## Why
These changes lower supply-chain and workflow-token risk while preserving the existing automated dependency update and installer deployment behavior.